### PR TITLE
0.0.13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Pow",
-            url: "https://packages.movingparts.io/binaries/pow/0.0.12/Pow.xcframework.zip",
-            checksum: "51f1479bb77bcdb775e0cfdfb14be5231185012e3fe8c2dcf994d381295a797c"
+            url: "https://packages.movingparts.io/binaries/pow/0.0.13/Pow.xcframework.zip",
+            checksum: "4fd8a2e00b886d5e5a41159a68f7991ba45217ad1e8690cb7f158cfa96fc831b"
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -334,6 +334,17 @@ Text("Hello")
 static func rotate3D(_ angle: Angle, axis: (x: CGFloat, y: CGFloat, z: CGFloat), anchor: UnitPoint = .center, anchorZ: CGFloat = 0, perspective: CGFloat = 1) -> AnyTransition
 ```
 
+## Snapshot
+
+[Preview](https://movingparts.io/pow/#film-exposure)
+
+A transition from completely bright to fully visible on insertion, and
+from fully visible to completely bright on removal.
+
+```swift
+static var filmExposure: AnyTransition
+```
+
 ## Skid
 
 [Preview](https://movingparts.io/pow/#skid)

--- a/README.md
+++ b/README.md
@@ -336,13 +336,13 @@ static func rotate3D(_ angle: Angle, axis: (x: CGFloat, y: CGFloat, z: CGFloat),
 
 ## Snapshot
 
-[Preview](https://movingparts.io/pow/#film-exposure)
+[Preview](https://movingparts.io/pow/#snapshot)
 
 A transition from completely bright to fully visible on insertion, and
 from fully visible to completely bright on removal.
 
 ```swift
-static var filmExposure: AnyTransition
+static var snapshot: AnyTransition
 ```
 
 ## Skid

--- a/README.md
+++ b/README.md
@@ -385,6 +385,9 @@ A transition that dissolves the view into many small particles.
 
 The transition is only performed on removal.
 
+> **Note:**
+> This transition will use an ease-out animation with a duration of 900ms by default.
+
 ```swift
 static var vanish: AnyTransition
 ```
@@ -392,6 +395,9 @@ static var vanish: AnyTransition
 A transition that dissolves the view into many small particles.
 
 The transition is only performed on removal.
+
+> **Note:**
+> This transition will use an ease-out animation with a duration of 900ms by default.
 
 - Parameter `style`: The style to use for the particles.
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ before settling.
 static func flicker(count: Int) -> AnyTransition
 ```
 
+## Film Exposure
+
+[Preview](https://movingparts.io/pow/#film-exposure)
+
+A transition from completely dark to fully visible on insertion, and
+from fully visible to completely dark on removal.
+
+```swift
+static var filmExposure: AnyTransition
+```
+
 ## Flip
 
 [Preview](https://movingparts.io/pow/#flip)


### PR DESCRIPTION
- Adds two new transitions, `.filmExposure` and `.snapshot`.
- `.vanish` will now use it's predefined transition only if the current transition uses the `.default` animation.