### PR TITLE
0.2.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .binaryTarget(
             name: "Pow",
             url: "https://packages.movingparts.io/binaries/pow/0.2.0/Pow.xcframework.zip",
-            checksum: "a0276143d0cf97d90d3adbbf918e79ccccafc8f30cef7d50c5829baa9451c91a"
+            checksum: "a3b2f1b8714002631293dec6087068017e1b3744f4d462c99a5c385abcbcd600"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .binaryTarget(
             name: "Pow",
             url: "https://packages.movingparts.io/binaries/pow/0.2.0/Pow.xcframework.zip",
-            checksum: "aea635077d8cddc57fe37cddfbdc2ee43676c3e6a12ba93eedb6f48173f76dd9"
+            checksum: "0c3f180360d4beee3029bf7a24cf2f089836209ff8a2538a9cd0d9a28b473046"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .binaryTarget(
             name: "Pow",
             url: "https://packages.movingparts.io/binaries/pow/0.2.0/Pow.xcframework.zip",
-            checksum: "c2a61e0a0444da2aa6b1c4813932e8c7ee3ddc485dad4fc2bfb03da689bfac9b"
+            checksum: "29dfc4ff23d68f1a693aff689b4ab58a81554ad346ab15e7bcc55907c41b090c"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .binaryTarget(
             name: "Pow",
             url: "https://packages.movingparts.io/binaries/pow/0.2.0/Pow.xcframework.zip",
-            checksum: "29dfc4ff23d68f1a693aff689b4ab58a81554ad346ab15e7bcc55907c41b090c"
+            checksum: "9a253884c397cd7d615ea848143fc32f9f85351417a5eae6dc84430b1c4baea6"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Pow",
-            url: "https://packages.movingparts.io/binaries/pow/0.1.1/Pow.xcframework.zip",
-            checksum: "5ae07875130ecb40d9310460b13da6aaa6f783d1e6e9af88b7c96a1ba32fd22a"
+            url: "https://packages.movingparts.io/binaries/pow/0.2.0/Pow.xcframework.zip",
+            checksum: "e4455686b25aff51a821bc46bc54c07cb4554e721d37d84fdbcf5e1e3dab59ef"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .binaryTarget(
             name: "Pow",
             url: "https://packages.movingparts.io/binaries/pow/0.2.0/Pow.xcframework.zip",
-            checksum: "0c3f180360d4beee3029bf7a24cf2f089836209ff8a2538a9cd0d9a28b473046"
+            checksum: "a53a9ea09101af0de662543cf9b833acb0d6e496ccc5737c2b6f5799bf50774c"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .binaryTarget(
             name: "Pow",
             url: "https://packages.movingparts.io/binaries/pow/0.2.0/Pow.xcframework.zip",
-            checksum: "e4455686b25aff51a821bc46bc54c07cb4554e721d37d84fdbcf5e1e3dab59ef"
+            checksum: "aea635077d8cddc57fe37cddfbdc2ee43676c3e6a12ba93eedb6f48173f76dd9"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .binaryTarget(
             name: "Pow",
             url: "https://packages.movingparts.io/binaries/pow/0.2.0/Pow.xcframework.zip",
-            checksum: "a53a9ea09101af0de662543cf9b833acb0d6e496ccc5737c2b6f5799bf50774c"
+            checksum: "c2a61e0a0444da2aa6b1c4813932e8c7ee3ddc485dad4fc2bfb03da689bfac9b"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .binaryTarget(
             name: "Pow",
             url: "https://packages.movingparts.io/binaries/pow/0.2.0/Pow.xcframework.zip",
-            checksum: "9a253884c397cd7d615ea848143fc32f9f85351417a5eae6dc84430b1c4baea6"
+            checksum: "dd12f4ed5db23a191964d40b0c74272b96a4a4912c706216b0387b046ee1f353"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .binaryTarget(
             name: "Pow",
             url: "https://packages.movingparts.io/binaries/pow/0.2.0/Pow.xcframework.zip",
-            checksum: "dd12f4ed5db23a191964d40b0c74272b96a4a4912c706216b0387b046ee1f353"
+            checksum: "a0276143d0cf97d90d3adbbf918e79ccccafc8f30cef7d50c5829baa9451c91a"
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ likeButton
   )
 ```
 
-This effect respects `particleGroup()`.
-
 - Parameters:
   - `origin`: The origin of the particles.
   - `layer`: The `ParticleLayer` on which to render the effect, default is `local`.
@@ -128,8 +126,6 @@ static func ping(shape: some InsettableShape, style: some ShapeStyle, count: Int
 [Preview](https://movingparts.io/pow/#rise)
 
 An effect that emits the provided particles from the origin point and slowly float up while moving side to side.
-
-This effect respects `particleGroup()`.
 
 - Parameters:
   - `origin`: The origin of the particle.

--- a/README.md
+++ b/README.md
@@ -49,22 +49,39 @@ likeButton
   )
 ```
 
+This effect respects `particleGroup()`.
+
 - Parameters:
   - `origin`: The origin of the particles.
+  - `layer`: The `ParticleLayer` on which to render the effect, default is `local`.
   - `particles`: The particles to emit.
 
 ```swift
-static func spray(origin: UnitPoint = .center, @ViewBuilder _ particles: () -> some View) -> AnyChangeEffect
+static func spray(origin: UnitPoint = .center, layer: ParticleLayer = .local, @ViewBuilder _ particles: () -> some View) -> AnyChangeEffect
 ```
 
 ### Haptic Feedback
 
-Triggers the given haptic feedback type whenever a value changes.
+Triggers haptic feedback to communicate successes, failures, and warnings whenever a value changes.
 
-- `feedback`: The feedback type beiged triggered.
+- `notification`: The feedback type to trigger.
 
 ```swift
-static func hapticFeedback(_ feedback: UINotificationFeedbackGenerator.FeedbackType) -> AnyChangeEffect
+static func feedback(hapticNotification type: UINotificationFeedbackGenerator.FeedbackType) -> AnyChangeEffect
+```
+
+Triggers haptic feedback to simulate physical impacts whenever a value changes.
+
+- `impact`: The feedback style to trigger.
+
+```swift
+static func feedback(hapticImpact style: UIImpactFeedbackGenerator.FeedbackStyle) -> AnyChangeEffect
+```
+
+Triggers haptic feedback to indicate a change in selection whenever a value changes.
+
+```swift
+static var feedbackHapticSelection: AnyChangeEffect
 ```
 
 ### Jump
@@ -112,12 +129,15 @@ static func ping(shape: some InsettableShape, style: some ShapeStyle, count: Int
 
 An effect that emits the provided particles from the origin point and slowly float up while moving side to side.
 
+This effect respects `particleGroup()`.
+
 - Parameters:
   - `origin`: The origin of the particle.
+  - `layer`: The `ParticleLayer` on which to render the effect, default is `local`.
   - `particles`: The particles to emit.
 
 ```swift
-static func rise(origin: UnitPoint = .center, @ViewBuilder _ particles: () -> some View) -> AnyChangeEffect
+static func rise(origin: UnitPoint = .center, layer: ParticleLayer = .local, @ViewBuilder _ particles: () -> some View) -> AnyChangeEffect
 ```
 
 ### Shake
@@ -160,7 +180,7 @@ static func shine(duration: Double) -> AnyChangeEffect
 
 Highlights the view with a shine moving over the view.
 
-The angle is relative to the current `layoutDirection`, such that 0° represents sweeping towards the trailing edge and 90° represents sweeping towards the top edge.
+The angle is relative to the current `layoutDirection`, such that 0° represents sweeping towards the trailing edge and 90° represents sweeping towards the bottom edge.
 
 - Parameters:
   - `angle`: The angle of the animation.
@@ -168,6 +188,16 @@ The angle is relative to the current `layoutDirection`, such that 0° represents
 
 ```swift
 static func shine(angle: Angle, duration: Double = 1.0) -> AnyChangeEffect
+```
+
+### Sound Effect Feedback
+
+Triggers a sound effect as feedback whenever a value changes.
+
+- `soundEffect`: The sound effect to trigger.
+
+```swift
+static func feedback(_ soundEffect: SoundEffect) -> AnyChangeEffect
 ```
 
 ### Spin
@@ -190,6 +220,40 @@ Spins the view around the given axis when a change happens.
 
 ```swift
 static func spin(axis: (x: CGFloat, y: CGFloat, z: CGFloat), anchor: UnitPoint = .center, anchorZ: CGFloat = 0, perspective: CGFloat = 1 / 6) -> AnyChangeEffect
+```
+
+### Delay
+
+Every change effect can be delayed to trigger the effect after some time. 
+
+```swift
+Button("Submit") { 
+    <#code#>
+}
+.buttonStyle(.borderedProminent)
+.disabled(name.isEmpty)
+.changeEffect(.shine.delay(1), value: name.isEmpty, isEnabled: !name.isEmpty)
+```
+
+- Parameters:
+  - `delay`: The delay in seconds.
+
+```swift
+func delay(_ delay: Double) -> AnyChangeEffect
+```
+
+## Particle Layer
+
+A particle layer is a context in which particle effects draw their particles.
+
+The `particleLayer(name:)` view modifier wraps the view in a particle layer with the given name.
+
+Particle effects such as `AnyChangeEffect.spray` can render their particles on this position in the view tree to avoid being clipped by their immediate ancestor.
+
+For example, certain `List` styles may clip their rows. Use `particleLayer(_:)` to render particles on top of the entire `List` or even its enclosing `NavigationStack`.
+
+```swift
+func particleLayer(name: AnyHashable) -> some View
 ```
 
 ## Transitions
@@ -255,8 +319,9 @@ elastic deformation of the view.
 static var boing: AnyTransition
 ```
 
-A transition that moves the view away towards the specified edge, with
-any overshoot resulting in an elastic deformation of the view.
+A transition that moves the view from the specified edge on insertion,    
+and towards it on removal, with any overshoot resulting in an elastic    
+deformation of the view.
 
 ```swift
 static func boing(edge: Edge) -> AnyTransition
@@ -340,8 +405,8 @@ A transitions that shows the view by combining a wipe with a colored
 streak.
 
 The angle is relative to the current `layoutDirection`, such that 0°
-represents sweeping towards the leading edge on insertion and 90°
-represents sweeping towards the top edge.
+represents sweeping towards the trailing edge on insertion and 90°
+represents sweeping towards the bottom edge.
 
 In this example, the removal of the view is using a glare with an
 exponential ease-in curve, combined with a anticipating scale animation,
@@ -400,7 +465,7 @@ static func move(edge: Edge) -> AnyTransition
 
 A transition that moves the view at the specified angle.
 
-The angle is relative to the current `layoutDirection`, such that 0° represents animating towards the leading edge on insertion and 90° represents inserting towards the top edge.
+The angle is relative to the current `layoutDirection`, such that 0° represents animating towards the trailing edge on insertion and 90° represents inserting towards the bottom edge.
 
 In this example, the view insertion is animated by moving it towards the top trailing corner and the removal is animated by moving it towards the bottom edge.
 
@@ -609,4 +674,18 @@ towards it on removal.
 
 ```swift
 static func wipe(edge: Edge, blurRadius: CGFloat = 0) -> AnyTransition
+```
+
+A transition using a sweep at the specified angle.
+
+The angle is relative to the current `layoutDirection`, such that 0° 
+represents sweeping towards the trailing edge on insertion and 90° 
+represents sweeping towards the bottom edge.
+
+- Parameters:
+  - `angle`: The angle of the animation.
+  - `blurRadius`: The radius of the blur applied to the mask.
+
+```swift
+static func wipe(angle: Angle, blurRadius: CGFloat = 0) -> AnyTransition
 ```

--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ static func shine(angle: Angle, duration: Double = 1.0) -> AnyChangeEffect
 
 Triggers a sound effect as feedback whenever a value changes.
 
+This effect will not interrupt or duck any other audio that may currently playing. It may also not triggered based on the setting of the user's silent switch or playback device.
+
+To relay important information to the user, you should always accompany audio effects with visual cues.
+
 - `soundEffect`: The sound effect to trigger.
 
 ```swift


### PR DESCRIPTION
## New in 0.2.0

> **Warning**
>
> Edges and angles for `.boing`, `.glare`, `.move`, and `.wipe` transitions as well as the `.shine` change effect have been changed to be consistent:
>  - `.boing` has a new default direction moving from the top instead of the bottom.
>  - `Angle` given to these transitions and effects are reversed from what they used to be meaning that a 90° angle now moves towards the bottom edge instead of the top edge.

- Added `sound` change effect.
- Added impact and selection haptic feedback types.
- Added `particleLayer(name:)` view modifier.
- `.glare` and `.vanish` now display with increased brightness.
- Added `delay(_:)` modifier to change effects.

### Haptics

In addition to notification haptics, you can now trigger also selection and impact haptics.

```swift
Picker("Color", selection: $color) {
    Text("Red").tag(.red)
    Text("Green").tag(.green)
    Text("Blue").tag(.blue)
}
.pickerStyle(.segmented)
.changeEffect(.feedbackHapticSelection, value: color)
```

### Sound Effects

This version of Pow introduces Sound Effects.

Play sound effects using the `.feedback(_:)` change effect.

```swift
Button(status.buttonLabelText) {
    Task {
        do {
            status = .inProgress
            try await processPayment()
            status = .paid
        } catch {
            status = .failed
        }
    }
}
.changeEffect(.feedback(SoundEffect("sparkle")), value: status == .paid, isEnabled: status == .paid)
.changeEffect(.feedback(SoundEffect("notfound")), value: status == .failed, isEnabled: status == .failed)
```

The sounds are looked up in the main `Bundle` by default. Common audio formats like `aiff`, `wav`, `caf`, and `m4a` are found automatically but you can also use other formats by specifying the type and if supported by the OS.

A set of sounds can be found in the [Pow Example repo](https://github.com/movingparts-io/Pow-Examples/tree/release/pow-0.2.0/Pow%20Example/Sounds) and are free to use with any licensed copy of Pow.

Our thanks to @mergesort for the feature requests to add more haptic feedback types and sound change effects 🙇

### Particle Layer

Particle effects such as `AnyChangeEffect.spray` can now render their particles in a different position in the view tree to avoid being clipped by their immediate ancestor.

For example, certain `List` styles may clip their rows. Use `particleLayer(_:)` to render particles on top of the entire `List` or even its enclosing `NavigationStack`.

```swift
NavigationStack {
    List(items) { item in
        HStack {
            Text(item.title)
            Image(systemName: "heart.fill")
                .changeEffect(.spray(layer: .named("root")) {
                    Image(systemName: "heart.fill")
                        .foregroundStyle(.red)
                }, value: item.likes)
        }
    }
}
.particleLayer(name: "root")
```

### Brighter `.glare` & `.vanish`

`.glare` and `.vanish` transitions now display with increased brightness giving a bit more punch to the effect. And for `.glare` it makes the shine show even on white backgrounds.

### Delay

You can now add a delay to change effects to change the timing of the change effects. This works well with the `.shine` effect for example where you might want the shine highlight to show some time after the button becomes enabled.

```swift
Button("Submit") { 
    // … 
}
.buttonStyle(.borderedProminent)
.disabled(name.isEmpty)
.changeEffect(.shine.delay(1), value: name.isEmpty, isEnabled: !name.isEmpty)
```

If you're interested in using Pow in your app, you can [purchase a license on our site](https://movingparts.io/pow). ✨

Thank you for your support!