### PR TITLE
0.3.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .binaryTarget(
             name: "Pow",
             url: "https://packages.movingparts.io/binaries/pow/0.3.1/Pow.xcframework.zip",
-            checksum: "d4a3deb1695350ba768b9e75a9e7d44d5271b0fe6abab30c41660581f7300667"
+            checksum: "d69a6023276202aeaca0e35e552647d95fece7a365af5bc243e264287ff75b68"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .binaryTarget(
             name: "Pow",
             url: "https://packages.movingparts.io/binaries/pow/0.3.1/Pow.xcframework.zip",
-            checksum: "0107203626acfe9a899774c333c22c4103773991a0f4901a747438c274e8865c"
+            checksum: "d4a3deb1695350ba768b9e75a9e7d44d5271b0fe6abab30c41660581f7300667"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Pow",
-            url: "https://packages.movingparts.io/binaries/pow/0.3.0/Pow.xcframework.zip",
-            checksum: "d60782300a127d66a5df56060a34643ef0e04e86dcd6558ea4f2a3617e196c5c"
+            url: "https://packages.movingparts.io/binaries/pow/0.3.1/Pow.xcframework.zip",
+            checksum: "0107203626acfe9a899774c333c22c4103773991a0f4901a747438c274e8865c"
         ),
     ]
 )


### PR DESCRIPTION
- Fixes an issue where repeat effects would unintentionally trigger when a view (re-)appears.
- Marks Pow as safe for application extensions.
- Reduce the amount of purchase reminders when running Pow in Xcode Previews.
- Fix `glow` effect preventing hit testing #29.